### PR TITLE
Closes #9013 - Ensure the session close method is called 

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -561,7 +561,7 @@ class JApplicationWeb extends JApplicationBase
 		}
 
 		// Close the application after the redirect.
-		$this->close();
+		$this->session->close();
 	}
 
 	/**


### PR DESCRIPTION
Ensure the session close method is called instead to ensure that session_write_close() is called before redirect

See PHP.net session_write_close comments

see #9013

To test, just edit some articles on the frontend - nothing should be broken. 