### PR TITLE
Add proxy for File::move to restore_finalisation.php

### DIFF
--- a/administrator/components/com_joomlaupdate/restore_finalisation.php
+++ b/administrator/components/com_joomlaupdate/restore_finalisation.php
@@ -91,7 +91,7 @@ namespace Joomla\CMS\Filesystem
 		abstract class File
 		{
 			/**
-			 * Proxies checking a folder exists to the native php version
+			 * Proxies checking a file exists to the native php version
 			 *
 			 * @param   string  $fileName  The path to the file to be checked
 			 *
@@ -117,6 +117,21 @@ namespace Joomla\CMS\Filesystem
 			{
 				$postproc = \AKFactory::getPostProc();
 				$postproc->unlink($fileName);
+			}
+			/**
+			 * Proxies moving a file to the restore.php version
+			 *
+			 * @param   string   $src         The path to the source file
+			 * @param   string   $dest        The path to the destination file
+			 *
+			 * @return  boolean  True on success
+			 *
+			 * @since   __DEPLOY_VERSION__
+			 */
+			public static function move($src, $dest)
+			{
+				$postproc = \AKFactory::getPostProc();
+				$postproc->rename($src, $dest);
 			}
 		}
 	}

--- a/administrator/components/com_joomlaupdate/restore_finalisation.php
+++ b/administrator/components/com_joomlaupdate/restore_finalisation.php
@@ -121,8 +121,8 @@ namespace Joomla\CMS\Filesystem
 			/**
 			 * Proxies moving a file to the restore.php version
 			 *
-			 * @param   string   $src         The path to the source file
-			 * @param   string   $dest        The path to the destination file
+			 * @param   string   $src   The path to the source file
+			 * @param   string   $dest  The path to the destination file
 			 *
 			 * @return  boolean  True on success
 			 *

--- a/administrator/components/com_joomlaupdate/restore_finalisation.php
+++ b/administrator/components/com_joomlaupdate/restore_finalisation.php
@@ -121,8 +121,8 @@ namespace Joomla\CMS\Filesystem
 			/**
 			 * Proxies moving a file to the restore.php version
 			 *
-			 * @param   string   $src   The path to the source file
-			 * @param   string   $dest  The path to the destination file
+			 * @param   string  $src   The path to the source file
+			 * @param   string  $dest  The path to the destination file
 			 *
 			 * @return  boolean  True on success
 			 *


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/32915#issuecomment-903135378 .

### Summary of Changes

Adds a proxy for the File::move to restore_finalisation.php.

### Testing Instructions

Code review, or make an update package and check if updating a 3.10-dev works on any kind of OS.

### Expected result

All fine.

### Actual result

See https://github.com/joomla/joomla-cms/pull/32915#issuecomment-903135378 .

### Documentation Changes Required

None.