### PR TITLE
[CMS PR 35347] Same change also for $auth_method = 'bind'

### DIFF
--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -144,7 +144,7 @@ class PlgAuthenticationLdap extends CMSPlugin
 				{
 					$ldap->bind($ldap->escape($credentials['username'], '', LDAP_ESCAPE_DN), $credentials['password']);
 				}
-				catch (ConnectionException $exception)
+				catch (ConnectionException | LdapException $exception)
 				{
 					$response->status = Authentication::STATUS_FAILURE;
 					$response->error_message = Text::_('JGLOBAL_AUTH_INVALID_PASS');


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/35347 .

### Summary of Changes

PR https://github.com/joomla/joomla-cms/pull/35347 solves the issue only if Authorisation Method "Bind and search" is used, but not if "Bind Directly as User" is used.

This PR here adds the same change to that case of the switch statement.

### Testing Instructions

Test as described in https://github.com/joomla/joomla-cms/pull/35347 with settings as shown in the screenshot and the Authorisation Method set to "Bind Directly as User". 

### Expected result

Alert shown that user name or password not matching.

### Actual result

Unhandled exception.

### Documentation Changes Required

Do we have documentation? ;-)